### PR TITLE
Fix Module Installation Path error

### DIFF
--- a/Application/Controller/Admin/DevModuleMetadata.php
+++ b/Application/Controller/Admin/DevModuleMetadata.php
@@ -212,7 +212,8 @@ class DevModuleMetadata extends \OxidEsales\Eshop\Application\Controller\Admin\A
 
             // update yaml config files
             $moduleConfigurationInstallerService = $container->get(ModuleConfigurationInstallerInterface::class);
-            $moduleConfigurationInstallerService->install($oModule->getModuleFullPath(), $oModule->getModuleFullPath());
+            $modulePath = $this->getCorrectedPath($oModule);
+            $moduleConfigurationInstallerService->install($modulePath, $modulePath);
 
             // update cached metadata in database
             //$moduleConfigurationDao = $container->get(ModuleConfigurationDaoInterface::class);
@@ -251,5 +252,15 @@ class DevModuleMetadata extends \OxidEsales\Eshop\Application\Controller\Admin\A
             Registry::getLogger()->error($exception->getMessage(), [$exception]);
             //die("MESSAGE_REACTIVATION_FAILED");
         }
+    }
+
+    private function getCorrectedPath($oModule) {
+        $modulePath = str_replace('../', '', $oModule->getModuleFullPath());
+        $search = 'shop/source/modules/';
+        $pos = strpos($modulePath, $search);
+        if ($pos !== false) {
+            $modulePath = substr_replace($modulePath, '', $pos, strlen($search));
+        }
+        return $modulePath;
     }
 }

--- a/metadata.php
+++ b/metadata.php
@@ -16,12 +16,12 @@ $sMetadataVersion = '2.1';
 $aModule = [
     'id' => 'vt-devutils',
     'title' => '[vt] DevUtils',
-    'description' => 'developent utilities for OXID eShop V6.2',
+    'description' => 'developent utilities for OXID eShop V6.2, forked repository',
     'thumbnail' => 'devutils.jpg',
     'version' => '2.1.1',
     'author' => 'Marat Bedoev',
     'email' => openssl_decrypt("Az6pE7kPbtnTzjHlPhPCa4ktJLphZ/w9gKgo5vA//p4=", str_rot13("nrf-128-pop"), str_rot13("gvalzpr")),
-    'url' => 'https://github.com/vanilla-thunder/oxid-module-devutils',
+    'url' => 'https://github.com/pejovskis/oxid-module-devutils/tree/fix-module-path',
     'extend' => [
         //\OxidEsales\Eshop\Application\Controller\Admin\ModuleMain::class  => VanillaThunder\DevUtils\Application\Extend\ModuleMain::class,
         \OxidEsales\Eshop\Application\Controller\Admin\NavigationController::class => VanillaThunder\DevUtils\Application\Extend\Controller\NavigationController::class,

--- a/metadata.php
+++ b/metadata.php
@@ -18,7 +18,7 @@ $aModule = [
     'title' => '[vt] DevUtils',
     'description' => 'developent utilities for OXID eShop V6.2, forked repository',
     'thumbnail' => 'devutils.jpg',
-    'version' => '2.1.1',
+    'version' => '2.1.9',
     'author' => 'Marat Bedoev',
     'email' => openssl_decrypt("Az6pE7kPbtnTzjHlPhPCa4ktJLphZ/w9gKgo5vA//p4=", str_rot13("nrf-128-pop"), str_rot13("gvalzpr")),
     'url' => 'https://github.com/pejovskis/oxid-module-devutils/tree/fix-module-path',


### PR DESCRIPTION
In Oxid 6.5 haben wir plötzlich das Phänomen, dass der Pfad der Module verschluckt wird und unnötige "../../../../"-Symbole erzeugt, was die Reinstallation über die BE-Metadaten nicht möglich macht.

Die kleine Funktion behebt das Phantom-Problem der Erweiterung des Modulpfads um "../../../../" und ermöglicht die Neuinstallation des Moduls über die BE-Metadaten.